### PR TITLE
Membership inference attack references

### DIFF
--- a/references.md
+++ b/references.md
@@ -28,6 +28,7 @@
 - Protection of data confidentiality:
 
   - [The secret-sharer: evaluating and testing unintended memorization in neural networks](https://blog.acolyer.org/2019/09/23/the-secret-sharer/)
+  - [Membership Inference Attacks against Machine Learning Models](https://arxiv.org/abs/1610.05820) and further analysis [Demystifying the membership inference attack](https://medium.com/disaitek/demystifying-the-membership-inference-attack-e33e510a0c39)
 
 ## Travaux dans ce domaine
 

--- a/references.md
+++ b/references.md
@@ -28,7 +28,7 @@
 - Protection of data confidentiality:
 
   - [The secret-sharer: evaluating and testing unintended memorization in neural networks](https://blog.acolyer.org/2019/09/23/the-secret-sharer/)
-  - [Membership Inference Attacks against Machine Learning Models](https://arxiv.org/abs/1610.05820) and further analysis [Demystifying the membership inference attack](https://medium.com/disaitek/demystifying-the-membership-inference-attack-e33e510a0c39)
+  - [Membership Inference Attacks against Machine Learning Models](https://arxiv.org/abs/1610.05820) and further analysis [Demystifying the membership inference attack](https://medium.com/disaitek/demystifying-the-membership-inference-attack-e33e510a0c39). [A tool](https://github.com/privacytrustlab/ml_privacy_meter) to quantify the privacy risks of machine learning models with respect to inference attacks is also available.
 
 ## Travaux dans ce domaine
 


### PR DESCRIPTION
Adding the link to the research article for:
- The membership inference attack article by Shokri et al.
- A deeper analysis of this vulnerability by Disaitek
- The ml_privacy_meter tool 

This commit solves issue #42.
